### PR TITLE
Fix bug with not set cudaSolverSettings on non-default device

### DIFF
--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -24,6 +24,8 @@ Settings::Initialize ()
     prepareDeviceSettings ();
   }
 #endif /* CUDA_ENABLED */
+
+  isInitialized = true;
 } /* Settings::Initialize */
 
 /**
@@ -39,6 +41,8 @@ Settings::Uninitialize ()
     freeDeviceSettings ();
   }
 #endif /* CUDA_ENABLED */
+
+  ASSERT (isInitialized);
 } /* Settings::Uninitialize */
 
 /**
@@ -462,8 +466,6 @@ Settings::SetupFromCmd (int argc, /**< number of arguments */
                         char **argv) /**< arguments */
 {
   int status = setFromCmd (argc, argv, true);
-
-  Initialize ();
 
   switch (status)
   {

--- a/Source/Settings/Settings.h
+++ b/Source/Settings/Settings.h
@@ -131,6 +131,12 @@ private:
    */
   int gpuIndexForNode;
 
+
+  /**
+   * Flag whether settings have been initialized
+   */
+  bool isInitialized;
+
 #define SETTINGS_ELEM_FIELD_TYPE_NONE(fieldName, getterName, fieldType, defaultVal, cmdArg, description) \
   fieldType fieldName;
 #define SETTINGS_ELEM_FIELD_TYPE_INT(fieldName, getterName, fieldType, defaultVal, cmdArg, description) \
@@ -167,6 +173,7 @@ public:
     : dimension (0)
     , schemeType (SchemeType::NONE)
     , gpuIndexForNode (NO_GPU)
+    , isInitialized (false)
 #define SETTINGS_ELEM_FIELD_TYPE_NONE(fieldName, getterName, fieldType, defaultVal, cmdArg, description) \
     , fieldName ((fieldType) defaultVal)
 #define SETTINGS_ELEM_FIELD_TYPE_INT(fieldName, getterName, fieldType, defaultVal, cmdArg, description) \

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -46,11 +46,6 @@ static void cudaInfo ()
     printf("  Peak Memory Bandwidth (GB/s): %f\n\n", 2.0*prop.memoryClockRate*(prop.memoryBusWidth/8)/1.0e6);
   }
 }
-
-void cudaInit (int rank)
-{
-  cudaCheckErrorCmd (cudaSetDevice(rank));
-}
 #endif /* CUDA_ENABLED */
 
 #ifdef PARALLEL_GRID
@@ -1146,7 +1141,7 @@ int runMode (int argc, char** argv)
 
       if (idxGPU[rank] != NO_GPU)
       {
-        cudaInit (idxGPU[rank]);
+        cudaCheckErrorCmd (cudaSetDevice(idxGPU[rank]));
       }
 
       if (isParallel)
@@ -1166,6 +1161,8 @@ int runMode (int argc, char** argv)
       cudaThreadsZ = solverSettings.getNumCudaThreadsZ ();
     }
 #endif
+
+    solverSettings.Initialize ();
 
     Scheme<Type, TCoord, layout_type > scheme (yeeLayout,
                                                isParallel,

--- a/Tests/unit-test-internalscheme.cpp
+++ b/Tests/unit-test-internalscheme.cpp
@@ -1930,6 +1930,8 @@ int main (int argc, char** argv)
   }
 #endif /* CUDA_ENABLED */
 
+  solverSettings.Initialize ();
+
 #if defined (MODE_EX_HY)
   test1D_ExHy<E_CENTERED> ();
   test1D_ExHy<H_CENTERED> ();


### PR DESCRIPTION
cudaSetDevice should be called prior all other Cuda API calls,
because before cudaSetDevice all activity happens with regards to the context
of the default device (0). For example, if memory is allocated,
it is allocated on the default device, and won't be available
after cudaSetDevice(i) call (if i != 0).