### PR TITLE
Add GCC toolchain file for Raspberry Pi

### DIFF
--- a/Docs/Build.md
+++ b/Docs/Build.md
@@ -116,3 +116,21 @@ Add this to `cmake` command:
 ```
 -DLINK_NUMA=ON
 ```
+
+# Cross build for Raspberry Pi
+
+Download Raspbian image file (https://www.raspberrypi.org/downloads/raspbian/) and create rootfs:
+
+```
+mkdir /mnt/rpi
+mount -o ro,loop,offset=<offset> -t auto <path_to_image> /mnt/rpi
+```
+
+To get offset run:
+```
+fdisk -l <path_to_image> | grep "Linux" | awk '{print $2 * 512}'
+```
+
+Then pass `-DCMAKE_TOOLCHAIN_FILE=<path_to_arm-gcc-toolchain.cmake>`.
+
+By default, Raspberry Pi cmake toolchain file is configured to use rootfs files from `/mnt/rpi`. Note that rootfs should match image installed on your Raspberry Pi.

--- a/arm-gcc-toolchain.cmake
+++ b/arm-gcc-toolchain.cmake
@@ -1,0 +1,31 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
+
+set(TOOLCHAIN "arm-linux-gnueabihf")
+set(TOOLCHAIN_VERSION "8")
+set(CROSS_ROOTFS "/mnt/rpi")
+
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+
+include_directories(BEFORE SYSTEM ${CROSS_ROOTFS}/usr/include/c++/${TOOLCHAIN_VERSION})
+include_directories(BEFORE SYSTEM ${CROSS_ROOTFS}/usr/include/${TOOLCHAIN}/c++/${TOOLCHAIN_VERSION})
+
+set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
+
+add_link_options("-L${CROSS_ROOTFS}/lib")
+add_link_options("-L${CROSS_ROOTFS}/usr/lib")
+add_link_options("-L${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}/${TOOLCHAIN_VERSION}")
+add_link_options("-L${CROSS_ROOTFS}/usr/lib/${TOOLCHAIN}/")
+add_link_options("-L${CROSS_ROOTFS}/lib/${TOOLCHAIN}/")
+
+add_compile_options(-mthumb)
+add_compile_options(-mfpu=vfpv3)
+add_compile_options(-mfloat-abi=hard)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
Note: --sysroot option of GCC doesn't work by itself, -I and -L are still required.